### PR TITLE
Fix condvar double panic in tests

### DIFF
--- a/src/shared/event.rs
+++ b/src/shared/event.rs
@@ -45,7 +45,7 @@ impl Event {
                 Some(timeout) => {
                     // Get the current time and lazily compute when we started waiting.
                     let now = Instant::now();
-                    let start = started.unwrap_or_else(|| Instant::now());
+                    let start = started.unwrap_or_else(|| now);
                     started = Some(start);
 
                     // Check if we've been waiting for longer than the timeout


### PR DESCRIPTION
- Use a single Instant::now() for relative wait time starting point in Event::wait(). `now - start` was panicking as `start` could've been sampled after `now`.

- Reacquire mutex via Drop instead of manually in `Condvar::wait()`. This ensures the lock is held again even when unwinding. The second panic was Mutex::unlock() hitting an assert from lack of reacquire when unwinding.