### PR TITLE
Use address of thread-local variable for thread IDs

### DIFF
--- a/src/thread_id.rs
+++ b/src/thread_id.rs
@@ -1,9 +1,4 @@
-use std::{
-    mem::size_of,
-    num::NonZeroUsize,
-    ptr,
-    thread::{self, ThreadId},
-};
+use std::num::NonZeroUsize;
 
 /// Implementation of the `GetThreadId` trait for `lock_api::ReentrantMutex`.
 #[derive(Default, Debug)]
@@ -13,11 +8,9 @@ unsafe impl lock_api::GetThreadId for RawThreadId {
     const INIT: Self = Self;
 
     fn nonzero_thread_id(&self) -> NonZeroUsize {
-        let thread_id = thread::current().id();
-        assert!(size_of::<ThreadId>() >= size_of::<NonZeroUsize>());
-
-        // TODO: https://github.com/rust-lang/rust/issues/67939
-        let id_ptr = &thread_id as *const ThreadId;
-        unsafe { ptr::read_unaligned(id_ptr as *const NonZeroUsize) }
+        // The address of a thread-local is guaranteed to
+        // be unique to the current thread and non-zero (null)
+        thread_local!(static ID: bool = false);
+        ID.with(|id| NonZeroUsize::new(id as *const _ as usize).unwrap())
     }
 }


### PR DESCRIPTION
On 32-bit big-endian platforms, the current code is unsound.