### PR TITLE
Update advantages over types in std

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,12 @@ It also provides a `ReentrantMutex` type which supports recursive locking.
 The primitives provided by this library have several advantages over those
 in the Rust standard library:
 
-1. All types require only require 1 word of storage space. On the other hand on
-   some platforms (macOS and a few others) the standard library primitives require a
-   dynamically allocated `Box` to hold OS-specific synchronization primitives.
-   The small size of `Mutex` in particular encourages the use of fine-grained
-   locks to increase parallelism.
-2. Since they consist of just a single atomic variable, have constant
-   initializers and don't need destructors, these primitives can be used as
-   `static` global variables.
-3. Uncontended lock acquisition and release is done through fast inline
-   paths which only require a single atomic operation.
+
+1. All types require only 1 word of storage (unlike stdlib which stores
+   more state for poison detection).
+2. Static initializers for all types (stdlib doesn't yet have this for Barrier).
+3. Inline uncontested paths and micro-contention handled with bounded,
+   adaptive spinning.
 4. Microcontention (a contended lock with a short critical section) is
    efficiently handled by spinning a few times while trying to acquire a
    lock.

--- a/README.md
+++ b/README.md
@@ -14,16 +14,14 @@ It also provides a `ReentrantMutex` type which supports recursive locking.
 The primitives provided by this library have several advantages over those
 in the Rust standard library:
 
-1. All types require only require 1 word of storage space. On the other hand the
-   standard library primitives require a dynamically allocated `Box` to hold
-   OS-specific synchronization primitives. The small size of `Mutex` in
-   particular encourages the use of fine-grained locks to increase
-   parallelism.
+1. All types require only require 1 word of storage space. On the other hand on
+   some platforms (macOS and a few others) the standard library primitives require a
+   dynamically allocated `Box` to hold OS-specific synchronization primitives.
+   The small size of `Mutex` in particular encourages the use of fine-grained
+   locks to increase parallelism.
 2. Since they consist of just a single atomic variable, have constant
    initializers and don't need destructors, these primitives can be used as
-   `static` global variables. The standard library primitives require
-   dynamic initialization and thus need to be lazily initialized with
-   `lazy_static!`.
+   `static` global variables.
 3. Uncontended lock acquisition and release is done through fast inline
    paths which only require a single atomic operation.
 4. Microcontention (a contended lock with a short critical section) is

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ in the Rust standard library:
 4. `Condvar::notify_all` will generally only wake up a single thread and requeue the
     rest to wait on the associated `Mutex`. This avoids a thundering herd
     problem where all threads try to acquire the lock at the same time.
-5. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
-6. `Mutex<()>` and `RwLock<()>` allow raw locking without a RAII guard
-    object.
-7. A `ReentrantMutex` type which supports recursive locking.
-8. Lock guards can be sent to other threads when the `send_guard` feature is
+5. `Mutex` and `RwLock` allow raw locking and unlocking without a RAII guard object.
+6. A `ReentrantMutex` type which supports recursive locking.
+7. Lock guards can be sent to other threads when the `send_guard` feature is
     enabled.
 
 ## Userspace queues

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ It also provides a `ReentrantMutex` type which supports recursive locking.
 The primitives provided by this library have several advantages over those
 in the Rust standard library:
 
-
 1. All types require only 1 word of storage (unlike stdlib which stores
    more state for poison detection).
 2. Static initializers for all types (stdlib doesn't yet have this for Barrier).

--- a/README.md
+++ b/README.md
@@ -19,20 +19,14 @@ in the Rust standard library:
 2. Static initializers for all types (stdlib doesn't yet have this for Barrier).
 3. Inline uncontested paths and micro-contention handled with bounded,
    adaptive spinning.
-4. Microcontention (a contended lock with a short critical section) is
-   efficiently handled by spinning a few times while trying to acquire a
-   lock.
-5. The locks are adaptive and will suspend a thread after a few failed spin
-   attempts. This makes the locks suitable for both long and short critical
-   sections.
-6. `Condvar::notify_all` will generally only wake up a single thread and requeue the
+4. `Condvar::notify_all` will generally only wake up a single thread and requeue the
     rest to wait on the associated `Mutex`. This avoids a thundering herd
     problem where all threads try to acquire the lock at the same time.
-7. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
-8. `Mutex<()>` and `RwLock<()>` allow raw locking without a RAII guard
+5. `Mutex` and `RwLock` allow raw unlocking without a RAII guard object.
+6. `Mutex<()>` and `RwLock<()>` allow raw locking without a RAII guard
     object.
-9. A `ReentrantMutex` type which supports recursive locking.
-10. Lock guards can be sent to other threads when the `send_guard` feature is
+7. A `ReentrantMutex` type which supports recursive locking.
+8. Lock guards can be sent to other threads when the `send_guard` feature is
     enabled.
 
 ## Userspace queues


### PR DESCRIPTION
`Mutex`, `RwLock` and `CondVar` are const-constructible in `std` since [Rust 1.63](https://blog.rust-lang.org/2022/08/11/Rust-1.63.0.html#const-mutex-rwlock-condvar-initialization). In most platforms `pthread` locks have been replaced with ones that do not allocate.

Maybe it should be noted that points 1-5 are implemented in `std` for most platforms?