### PR TITLE
Replace `asm!("lock bts")` with compiler-lowered equivalent on x86

### DIFF
--- a/src/shared/strict_provenance.rs
+++ b/src/shared/strict_provenance.rs
@@ -48,6 +48,8 @@ pub(crate) trait AtomicPtrRmw<T> {
     fn fetch_add(&self, value: T, ordering: Ordering) -> T;
 
     fn fetch_sub(&self, value: T, ordering: Ordering) -> T;
+
+    fn fetch_ptr_or(&self, value: T, ordering: Ordering) -> T;
 }
 
 impl<T> AtomicPtrRmw<*mut T> for AtomicPtr<T> {
@@ -66,6 +68,15 @@ impl<T> AtomicPtrRmw<*mut T> for AtomicPtr<T> {
                 .cast::<AtomicUsize>()
                 .as_ref()
                 .fetch_sub(value.address(), ordering) as *mut T
+        }
+    }
+
+    fn fetch_ptr_or(&self, value: *mut T, ordering: Ordering) -> *mut T {
+        unsafe {
+            NonNull::from(self)
+                .cast::<AtomicUsize>()
+                .as_ref()
+                .fetch_or(value.address(), ordering) as *mut T
         }
     }
 }


### PR DESCRIPTION
Since version 1.65, rustc correctly lowers `fetch_or` of single bits to `lock bts` ([Godbolt](https://godbolt.org/z/W7Yf9Mjvc)). This PR uses this to replace the hand-coded `asm` version of `try_lock_exclusive_fast`.